### PR TITLE
ダウンロード時のリネームなど

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -173,7 +173,7 @@ export const fetch = async (): Promise<void> => {
         const writeStream = createWriteStream(downloadDirectory.poster);
         await data.pipe(writeStream);
         await new Promise<void>((resolve, reject) => {
-          writeStream.on('finish', () => {
+          writeStream.on('close', () => {
             promises.rename(downloadDirectory.poster, gameDirectory.poster);
             resolve();
           });
@@ -197,7 +197,7 @@ export const fetch = async (): Promise<void> => {
         const writeStream = createWriteStream(downloadDirectory.video);
         await data.pipe(writeStream);
         await new Promise<void>((resolve, reject) => {
-          writeStream.on('finish', () => {
+          writeStream.on('close', () => {
             promises.rename(downloadDirectory.video, gameDirectory.video);
             resolve();
           });

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,6 +1,5 @@
 import { createWriteStream, promises } from 'fs';
 import path from 'path';
-import promiseFilter from './utils/promiseFilter';
 import {
   getGameFile,
   getGameImage,
@@ -167,6 +166,10 @@ export const fetch = async (): Promise<void> => {
 
         const { data } = await getGameImage(gameId);
 
+        promises.unlink(gameDirectory.poster).catch(() => {
+          return;
+        });
+
         const writeStream = createWriteStream(downloadDirectory.poster);
         await data.pipe(writeStream);
         await new Promise<void>((resolve, reject) => {
@@ -186,6 +189,10 @@ export const fetch = async (): Promise<void> => {
         }
         //303リダイレクトなので型が通らない
         const { data } = (await getGameVideo(gameId)) as { data: any };
+
+        promises.unlink(gameDirectory.video).catch(() => {
+          return;
+        });
 
         const writeStream = createWriteStream(downloadDirectory.video);
         await data.pipe(writeStream);

--- a/src/lib/main.ts
+++ b/src/lib/main.ts
@@ -65,6 +65,11 @@ const createWindow = (): void => {
   }
 };
 
+const gotTheLock = app.requestSingleInstanceLock();
+if (!gotTheLock) {
+  app.quit();
+}
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.

--- a/src/lib/utils/unzip.ts
+++ b/src/lib/utils/unzip.ts
@@ -11,6 +11,10 @@ const unzip = async (
   md5: string,
   onDownload: () => void
 ) => {
+  await promises.unlink(downloadPath).catch(() => {
+    return;
+  });
+
   const stream = createWriteStream(downloadPath);
   data.pipe(stream);
 

--- a/src/lib/utils/unzip.ts
+++ b/src/lib/utils/unzip.ts
@@ -19,7 +19,7 @@ const unzip = async (
   data.pipe(stream);
 
   await new Promise<void>((resolve, reject) => {
-    stream.on('finish', async () => {
+    stream.on('close', async () => {
       onDownload();
 
       await promises.rename(downloadPath, absolutePath);

--- a/src/lib/utils/unzip.ts
+++ b/src/lib/utils/unzip.ts
@@ -1,4 +1,4 @@
-import { createWriteStream, mkdirSync, writeFileSync } from 'fs';
+import { createWriteStream, mkdirSync, writeFileSync, promises } from 'fs';
 import path from 'path';
 import AdmZip from 'adm-zip';
 import iconv from 'iconv-lite';
@@ -6,16 +6,19 @@ import { md5sumFile } from './checksum';
 
 const unzip = async (
   data: any,
+  downloadPath: string,
   absolutePath: string,
   md5: string,
   onDownload: () => void
 ) => {
-  const stream = createWriteStream(absolutePath);
+  const stream = createWriteStream(downloadPath);
   data.pipe(stream);
 
   await new Promise<void>((resolve, reject) => {
     stream.on('finish', async () => {
       onDownload();
+
+      await promises.rename(downloadPath, absolutePath);
 
       // checksum
       const md5sum = await md5sumFile(absolutePath).catch(() => undefined);

--- a/src/renderer/views/Title/index.tsx
+++ b/src/renderer/views/Title/index.tsx
@@ -87,6 +87,7 @@ const ProductKeyInput = styled(Cleave)<{ $invalidProductKey: boolean }>`
   color: ${(props) => props.theme.colors.text.primary};
   background-color: transparent;
   text-align: center;
+  transform: rotate(0.03deg);
 `;
 
 const EnterButton = styled(Div)<{ $isValidProductKey: boolean }>`


### PR DESCRIPTION
ダウンロード時に`xxx.traPCollection`→`xxx`と名前を変更
ダウンロード時に`xxx.traPCollection`ファイルを削除
アプリの二重起動を防止
ダウンロード完了のイベントとして`finish`を`close`に変更
プロダクトキー入力要素を少し傾ける
